### PR TITLE
Replace edu.ontotext.com with schools.ontotext.com

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -1,51 +1,51 @@
 This folder contains analysis of the ethnic population correlation with matura results.
 
-# SPARQL Queries 
+# SPARQL Queries
 
-Per subject and oblast count old teachers compared to all the teachers 
-Query showing merging of 2 datasets with 2-step aggregation 
+Per subject and oblast count old teachers compared to all the teachers
+Query showing merging of 2 datasets with 2-step aggregation
 
 ```sparql
 select ?region ?region_label ?subj ?subj_label ?total_teachers (sum(?old_teachers) as ?OLD_TEACHERS) {
 
-    {select ?region ?subj (sum(?n_teachers) as ?total_teachers) where { 
-  
+    {select ?region ?subj (sum(?n_teachers) as ?total_teachers) where {
+
     bind(subject:nmb_1 as ?subj)
-	?o a qb:Observation ; 
-    	qb:dataSet <cube/teachers_school_subject/2020-09-15>  ; 
-     	:subject ?subj ; 
-      	:school ?school ; 
+	?o a qb:Observation ;
+    	qb:dataSet <cube/teachers_school_subject/2020-09-15>  ;
+     	:subject ?subj ;
+      	:school ?school ;
         :quantity_people ?n_teachers ;
    .
-    ?school geo:sfWithin+ ?region . 
+    ?school geo:sfWithin+ ?region .
             ?region a :Region .
 	} group by ?region ?subj}
-    
+
     values ?ds {
         <cube/teachers_by_age_region/2020-09-15_F>
         <cube/teachers_by_age_region/2020-09-15_M>
     }
-	?o2 a qb:Observation ; 
-    		qb:dataSet ?ds  ; 
-     		:subject ?subj ; 
-      		:place ?region ; 
+	?o2 a qb:Observation ;
+    		qb:dataSet ?ds  ;
+     		:subject ?subj ;
+      		:place ?region ;
         	:quantity_people ?old_teachers ;
    	.
     ?region  rdfs:label ?region_label .
-    ?subj skos:prefLabel ?subj_label . 
+    ?subj skos:prefLabel ?subj_label .
     filter(lang(?region_label)="bg")
-} group by ?region ?region_label ?subj ?subj_label ?total_teachers 
+} group by ?region ?region_label ?subj ?subj_label ?total_teachers
 ```
 
 Death compare 2019-2020
 
 ```sparql
 PREFIX qb: <http://purl.org/linked-data/cube#>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
-BASE <https://schools.ontotext.com/resource/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
+BASE <https://schools.ontotext.com/data/resource/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-select ?place ?place_label (sum(?death_20) as ?total_20) (sum(?death_19) as ?total_19) ((?total_20/?total_19) as ?ratio) where { 
+select ?place ?place_label (sum(?death_20) as ?total_20) (sum(?death_19) as ?total_19) ((?total_20/?total_19) as ?ratio) where {
 	?s_19 qb:dataSet <cube/nsi_deaths/data> ; :year "2019"^^xsd:gYear ; :quantity_people ?death_19  ; :place ?place ; :week_number ?week .
 	?s_20 qb:dataSet <cube/nsi_deaths/data> ; :year "2020"^^xsd:gYear ; :quantity_people ?death_20  ; :place ?place ; :week_number ?week .
     ?place rdfs:label ?place_label .
@@ -58,24 +58,24 @@ Geo Demo - DZI mean by subj and by jurisdiction on YasGUY
 [YasGUY link to query](https://api.triplydb.com/s/DkUQTW-ut)
 
 ```sparql
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
-PREFIX school: <https://schools.ontotext.com/resource/school/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
+PREFIX school: <https://schools.ontotext.com/data/resource/school/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX subject: <https://schools.ontotext.com/resource/subject/>
+PREFIX subject: <https://schools.ontotext.com/data/resource/subject/>
 
-select ?subjectLabel (concat(?placeLab,"\n",?subjectLabel,"\n Средно: ",(str(avg(?grade))),"\n Общо Ученици: ",(str(sum(?num_students)))) as ?placeLabel) (concat("ranbow,",str((avg(?grade)-1)/5)) as ?placeColor) ?place where { 
-	bind(subject:nmb_1 as ?subj) 
+select ?subjectLabel (concat(?placeLab,"\n",?subjectLabel,"\n Средно: ",(str(avg(?grade))),"\n Общо Ученици: ",(str(sum(?num_students)))) as ?placeLabel) (concat("ranbow,",str((avg(?grade)-1)/5)) as ?placeColor) ?place where {
+	bind(subject:nmb_1 as ?subj)
     ?p a :Region ; rdfs:label ?placeLab ; :hasShape/geo:asWKT ?place .
-    
+
     ?o :grade_6 ?grade ; :school/geo:sfWithin+ ?p ; :subject ?subj ; :quantity_people ?num_students ; :date ?date .
-    
-    ?subj skos:prefLabel ?subjectLabel .  
+
+    ?subj skos:prefLabel ?subjectLabel .
     filter(lang(?placeLab)="bg")
 #    filter(year(?date) = 2019)
     filter(lang(?subjectLabel)="bg")
-} group by ?placeLab ?subjectLabel ?place 
+} group by ?placeLab ?subjectLabel ?place
 ```
 
 BEL DZI Mapped with Geosparql Nearby
@@ -85,9 +85,9 @@ BEL DZI Mapped with Geosparql Nearby
 ```sparql
 PREFIX omgeo: <http://www.ontotext.com/owlim/geo#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
-PREFIX subject: <https://schools.ontotext.com/resource/subject/>
+PREFIX subject: <https://schools.ontotext.com/data/resource/subject/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT * WHERE {
@@ -95,28 +95,28 @@ SELECT * WHERE {
  bind(xsd:double("23.3628094") as ?my_lon) #MY LONGITUDE
  ?s a :School ; :hasPoint ?point ; rdfs:label ?schoolName .
  ?point omgeo:nearby(?my_lat ?my_lon "3km") ; geo:asWKT ?school. # DISTANCE FROM ME
-    
+
  ?obs :school ?s ; :rank_percentile ?percentile ; :grade_6 ?grade_dzi ; :date ?date ; :subject subject:nmb_1 .
- 
+
  bind(concat(?schoolName," БЕЛ:",?grade_dzi) as ?schoolLabel)
  bind(concat("warm,",str(?percentile/100)) as ?schoolColor)
  filter(year(?date) = 2020)
-    
-} order by desc(?percentile) 
+
+} order by desc(?percentile)
 ```
 
 #ROMA villages
 
 https://api.triplydb.com/s/6zJ44Fxc0
 
-#Correl roma population 
+#Correl roma population
 
 ```sparql
 PREFIX qb: <http://purl.org/linked-data/cube#>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
-BASE <https://schools.ontotext.com/resource/>
-PREFIX ethnic_group: <https://schools.ontotext.com/resource/ethnic_group/>
-PREFIX subject: <https://schools.ontotext.com/resource/subject/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
+BASE <https://schools.ontotext.com/data/resource/>
+PREFIX ethnic_group: <https://schools.ontotext.com/data/resource/ethnic_group/>
+PREFIX subject: <https://schools.ontotext.com/data/resource/subject/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 select ?place_lab ?population ?roma_pop ?roma_ratio ?avg_dzi
 where {
@@ -131,26 +131,26 @@ where {
                    :ethnic_group ?eg ;
                    .
             bind(if(sameterm(?eg,ethnic_group:roma),?any,0) as ?roma)
-        } group by ?place 
+        } group by ?place
     }
     {
         select ?place (avg(?grade) as ?avg_dzi) {
             ?o_dzi qb:dataSet <cube/dzi/2020> ;
                    :grade_6 ?grade ;
-#                   :subject subject:nmb_1 
+#                   :subject subject:nmb_1
                    :school ?school ;
                    .
             ?school :place ?place .
-        } group by ?place 
+        } group by ?place
     }
 }
 ```
 
 Rank schools by number of observations
 
-```sparql 
-select ?school ?school_label (COUNT(?obs) AS ?num_obs) 
-where { 
+```sparql
+select ?school ?school_label (COUNT(?obs) AS ?num_obs)
+where {
 	?obs a qb:Observation .
 	?obs :school ?school .
 	?school rdfs:label ?school_label
@@ -160,51 +160,51 @@ where {
 Rank schools by percentile on all subject all years
 
 ```sparql
-select  
+select
 ?school ?school_label (avg(?perc) as ?avg_perc) (sum(?kids) as ?KIDS)
-where { 
+where {
 	?o :rank_percentile ?perc ; :school ?school ; :subject ?subj ; :quantity_people ?kids .
     ?school rdfs:label ?school_label .
-} 
-group by ?school ?school_label order by desc(?avg_grade) 
+}
+group by ?school ?school_label order by desc(?avg_grade)
 ```
 
 Rank schools by percentile on 1 subject all years
 
 ```sparql
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX subject: <https://schools.ontotext.com/resource/subject/>
-select  
+PREFIX subject: <https://schools.ontotext.com/data/resource/subject/>
+select
 ?school ?school_label (avg(?perc) as ?avg_perc) (sum(?kids) as ?KIDS)
-where { 
+where {
     bind(subject:nmb_35 as ?subj)
 	?o :rank_percentile ?perc ; :school ?school ; :subject ?subj ; :quantity_people ?kids .
-    ?school rdfs:label ?school_label . 
-} 
-group by ?school ?school_label order by desc(?avg_perc) 
+    ?school rdfs:label ?school_label .
+}
+group by ?school ?school_label order by desc(?avg_perc)
 ```
 
 # Debug
 
 ```sparql
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
-PREFIX place: <https://schools.ontotext.com/resource/place/>
-PREFIX subject: <https://schools.ontotext.com/resource/subject/>
+PREFIX place: <https://schools.ontotext.com/data/resource/place/>
+PREFIX subject: <https://schools.ontotext.com/data/resource/subject/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 select * where {
 #    values ?mun {
 #        place:Q2401780 #dupnica
-#    	place:Q628050  #blagoevgrad  
+#    	place:Q628050  #blagoevgrad
 #    }
 ?s a :School; :place/geo:sfWithin ?mun ; rdfs:label ?school_name .
-  
-    ?mun rdfs:label ?mun_label ; 
+
+    ?mun rdfs:label ?mun_label ;
          geo:sfWithin place:Q804311 ;
     .
-    
+
        ?o2 :school ?s ;
        :grade_level 12 ;
        :subject subject:nmb_1 ;
@@ -213,7 +213,7 @@ select * where {
        :quantity_people ?n_kids ;
     .
     filter(lang(?mun_label)="bg")
-} 
+}
 ```
 
 ## Haskovo School QCs

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -41,8 +41,8 @@ Death compare 2019-2020
 
 ```sparql
 PREFIX qb: <http://purl.org/linked-data/cube#>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
-BASE <http://edu.ontotext.com/resource/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
+BASE <https://schools.ontotext.com/resource/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 select ?place ?place_label (sum(?death_20) as ?total_20) (sum(?death_19) as ?total_19) ((?total_20/?total_19) as ?ratio) where { 
@@ -58,12 +58,12 @@ Geo Demo - DZI mean by subj and by jurisdiction on YasGUY
 [YasGUY link to query](https://api.triplydb.com/s/DkUQTW-ut)
 
 ```sparql
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
-PREFIX school: <http://edu.ontotext.com/resource/school/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX school: <https://schools.ontotext.com/resource/school/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX subject: <http://edu.ontotext.com/resource/subject/>
+PREFIX subject: <https://schools.ontotext.com/resource/subject/>
 
 select ?subjectLabel (concat(?placeLab,"\n",?subjectLabel,"\n Средно: ",(str(avg(?grade))),"\n Общо Ученици: ",(str(sum(?num_students)))) as ?placeLabel) (concat("ranbow,",str((avg(?grade)-1)/5)) as ?placeColor) ?place where { 
 	bind(subject:nmb_1 as ?subj) 
@@ -85,9 +85,9 @@ BEL DZI Mapped with Geosparql Nearby
 ```sparql
 PREFIX omgeo: <http://www.ontotext.com/owlim/geo#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
-PREFIX subject: <http://edu.ontotext.com/resource/subject/>
+PREFIX subject: <https://schools.ontotext.com/resource/subject/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT * WHERE {
@@ -113,10 +113,10 @@ https://api.triplydb.com/s/6zJ44Fxc0
 
 ```sparql
 PREFIX qb: <http://purl.org/linked-data/cube#>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
-BASE <http://edu.ontotext.com/resource/>
-PREFIX ethnic_group: <http://edu.ontotext.com/resource/ethnic_group/>
-PREFIX subject: <http://edu.ontotext.com/resource/subject/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
+BASE <https://schools.ontotext.com/resource/>
+PREFIX ethnic_group: <https://schools.ontotext.com/resource/ethnic_group/>
+PREFIX subject: <https://schools.ontotext.com/resource/subject/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 select ?place_lab ?population ?roma_pop ?roma_ratio ?avg_dzi
 where {
@@ -172,9 +172,9 @@ group by ?school ?school_label order by desc(?avg_grade)
 Rank schools by percentile on 1 subject all years
 
 ```sparql
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX subject: <http://edu.ontotext.com/resource/subject/>
+PREFIX subject: <https://schools.ontotext.com/resource/subject/>
 select  
 ?school ?school_label (avg(?perc) as ?avg_perc) (sum(?kids) as ?KIDS)
 where { 
@@ -188,11 +188,11 @@ group by ?school ?school_label order by desc(?avg_perc)
 # Debug
 
 ```sparql
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
-PREFIX place: <http://edu.ontotext.com/resource/place/>
-PREFIX subject: <http://edu.ontotext.com/resource/subject/>
+PREFIX place: <https://schools.ontotext.com/resource/place/>
+PREFIX subject: <https://schools.ontotext.com/resource/subject/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 select * where {
 #    values ?mun {

--- a/analysis/haskovo/nvo4_compare.rq
+++ b/analysis/haskovo/nvo4_compare.rq
@@ -1,13 +1,13 @@
-BASE  <https://schools.ontotext.com/resource/>
+BASE  <https://schools.ontotext.com/data/resource/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
-PREFIX subject: <https://schools.ontotext.com/resource/subject/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
+PREFIX subject: <https://schools.ontotext.com/data/resource/subject/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX schema: <http://schema.org/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX place: <https://schools.ontotext.com/resource/place/>
+PREFIX place: <https://schools.ontotext.com/data/resource/place/>
 PREFIX qb: <http://purl.org/linked-data/cube#>
-PREFIX cube: <https://schools.ontotext.com/resource/cube/>
+PREFIX cube: <https://schools.ontotext.com/data/resource/cube/>
 select
 ?oblLabel
 ?munLabel

--- a/analysis/haskovo/nvo4_compare.rq
+++ b/analysis/haskovo/nvo4_compare.rq
@@ -1,13 +1,13 @@
-BASE  <http://edu.ontotext.com/resource/>
+BASE  <https://schools.ontotext.com/resource/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
-PREFIX subject: <http://edu.ontotext.com/resource/subject/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX subject: <https://schools.ontotext.com/resource/subject/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX schema: <http://schema.org/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX place: <http://edu.ontotext.com/resource/place/>
+PREFIX place: <https://schools.ontotext.com/resource/place/>
 PREFIX qb: <http://purl.org/linked-data/cube#>
-PREFIX cube: <http://edu.ontotext.com/resource/cube/>
+PREFIX cube: <https://schools.ontotext.com/resource/cube/>
 select
 ?oblLabel
 ?munLabel

--- a/analysis/region_compare/README.md
+++ b/analysis/region_compare/README.md
@@ -3,9 +3,9 @@
 ## Mean DZI scores per municipality compared with municipality containing region capital
 
 ```sparql
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
-PREFIX subject: <http://edu.ontotext.com/resource/subject/>
+PREFIX subject: <https://schools.ontotext.com/resource/subject/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 select * where { 
 	?cap_mun a :Municipality ;
@@ -45,9 +45,9 @@ select * where {
 ## Mean DZI scores compared between region and capital municipality
 
 ```sparql
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
-PREFIX subject: <http://edu.ontotext.com/resource/subject/>
+PREFIX subject: <https://schools.ontotext.com/resource/subject/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 select * where { 
     

--- a/analysis/region_compare/README.md
+++ b/analysis/region_compare/README.md
@@ -1,13 +1,13 @@
-# Cross municipalities comparison 
+# Cross municipalities comparison
 
 ## Mean DZI scores per municipality compared with municipality containing region capital
 
 ```sparql
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
-PREFIX subject: <https://schools.ontotext.com/resource/subject/>
+PREFIX subject: <https://schools.ontotext.com/data/resource/subject/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-select * where { 
+select * where {
 	?cap_mun a :Municipality ;
           geo:sfWithin ?region ;
     	  rdfs:label ?cap_mun_label .
@@ -16,13 +16,13 @@ select * where {
     ?oth_mun a :Municipality ;
           geo:sfWithin ?region ;
          rdfs:label ?oth_mun_label ;
-    . 
+    .
     ?region rdfs:label ?region_label .
-    filter(lang(?cap_mun_label)="bg")      
-    filter(lang(?oth_mun_label)="bg")      
-    filter(lang(?region_label)="bg")      
+    filter(lang(?cap_mun_label)="bg")
+    filter(lang(?oth_mun_label)="bg")
+    filter(lang(?region_label)="bg")
     filter(!sameterm(?oth_mun,?cap_mun))
-    
+
     ?o :place ?cap_mun ;
        :grade_level 12 ;
        :subject subject:nmb_1 ;
@@ -30,7 +30,7 @@ select * where {
        :eval_score ?avg_grade_cap ;
        :quantity_people ?n_kids_cap ;
     .
-    
+
     ?o2 :place ?oth_mun ;
        :grade_level 12 ;
        :subject subject:nmb_1 ;
@@ -45,19 +45,19 @@ select * where {
 ## Mean DZI scores compared between region and capital municipality
 
 ```sparql
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
-PREFIX subject: <https://schools.ontotext.com/resource/subject/>
+PREFIX subject: <https://schools.ontotext.com/data/resource/subject/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-select * where { 
-    
+select * where {
+
     {select ?region ?date (sum(?points) as ?points_oth) (sum(?n_kids_oth) as ?sum_kids_oth) (?points_oth/?sum_kids_oth as ?avg_grade_oth) {
-    
+
     ?oth_mun a :Municipality ;
           geo:sfWithin ?region ;
     .
     ?cap_city :capital_of ?region .
-    filter not exists {?cap_city geo:sfWithin ?oth_mun}        
+    filter not exists {?cap_city geo:sfWithin ?oth_mun}
        ?o_oth :place ?oth_mun ;
        :grade_level 12 ;
        :subject subject:nmb_1 ;
@@ -67,16 +67,16 @@ select * where {
     .
     bind(?n_kids_oth*?avg_grade_oth_mun as ?points)
     } group by ?region ?date }
-    
+
 	?cap_mun a :Municipality ;
           geo:sfWithin ?region ;
     	  rdfs:label ?cap_mun_label .
     ?cap_city :capital_of ?region ;
   			 geo:sfWithin ?cap_mun .
     ?region rdfs:label ?region_label .
-    filter(lang(?cap_mun_label)="bg")         
-    filter(lang(?region_label)="bg")      
-    
+    filter(lang(?cap_mun_label)="bg")
+    filter(lang(?region_label)="bg")
+
     ?o :place ?cap_mun ;
        :grade_level 12 ;
        :subject subject:nmb_1 ;
@@ -84,7 +84,7 @@ select * where {
        :eval_score ?avg_grade_mun ;
        :quantity_people ?n_kids_mun ;
     .
-    
+
     ?o2 :place ?region ;
        :grade_level 12 ;
        :subject subject:nmb_1 ;

--- a/analysis/sparql/dzi-comapre.rq
+++ b/analysis/sparql/dzi-comapre.rq
@@ -1,10 +1,10 @@
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
-PREFIX subject: <https://schools.ontotext.com/resource/subject/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
+PREFIX subject: <https://schools.ontotext.com/data/resource/subject/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX schema: <http://schema.org/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX school: <https://schools.ontotext.com/resource/school/>
+PREFIX school: <https://schools.ontotext.com/data/resource/school/>
 select ?oblLabel ?munLabel ?placeLabel ?school_id ?school_wd ?school_label ?score_21 ?kids_21 ?score_20 ?kids_20 ?score_19 ?kids_19
 where {
 

--- a/analysis/sparql/dzi-comapre.rq
+++ b/analysis/sparql/dzi-comapre.rq
@@ -1,10 +1,10 @@
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
-PREFIX subject: <http://edu.ontotext.com/resource/subject/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX subject: <https://schools.ontotext.com/resource/subject/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX schema: <http://schema.org/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX school: <http://edu.ontotext.com/resource/school/>
+PREFIX school: <https://schools.ontotext.com/resource/school/>
 select ?oblLabel ?munLabel ?placeLabel ?school_id ?school_wd ?school_label ?score_21 ?kids_21 ?score_20 ?kids_20 ?score_19 ?kids_19
 where {
 

--- a/analysis/sparql/matura-stem.rq
+++ b/analysis/sparql/matura-stem.rq
@@ -1,12 +1,12 @@
 PREFIX qb: <http://purl.org/linked-data/cube#>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
-BASE <https://schools.ontotext.com/resource/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
+BASE <https://schools.ontotext.com/data/resource/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX schema: <http://schema.org/>
-select ?province ?town ?school_wiki_id ?school ?year ?sub_group (sum(?num_pup) as ?tot_pup) (sum(?grade*?num_pup)/?tot_pup as ?average_grade) where { 
+select ?province ?town ?school_wiki_id ?school ?year ?sub_group (sum(?num_pup) as ?tot_pup) (sum(?grade*?num_pup)/?tot_pup as ?average_grade) where {
         ?s rdf:type qb:Observation;
            :date ?date;
            :grade_6 ?grade;

--- a/analysis/sparql/matura-stem.rq
+++ b/analysis/sparql/matura-stem.rq
@@ -1,6 +1,6 @@
 PREFIX qb: <http://purl.org/linked-data/cube#>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
-BASE <http://edu.ontotext.com/resource/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
+BASE <https://schools.ontotext.com/resource/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/analysis/sparql/vtora-matura.rq
+++ b/analysis/sparql/vtora-matura.rq
@@ -1,10 +1,10 @@
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
-PREFIX subject: <https://schools.ontotext.com/resource/subject/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
+PREFIX subject: <https://schools.ontotext.com/data/resource/subject/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX schema: <http://schema.org/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX school: <https://schools.ontotext.com/resource/school/>
+PREFIX school: <https://schools.ontotext.com/data/resource/school/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 select ?oblLabel ?munLabel ?placeLabel ?school_id ?school_wd ?school_label ?subject_label ?score_21 ?kids_21
 where {

--- a/analysis/sparql/vtora-matura.rq
+++ b/analysis/sparql/vtora-matura.rq
@@ -1,10 +1,10 @@
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
-PREFIX subject: <http://edu.ontotext.com/resource/subject/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX subject: <https://schools.ontotext.com/resource/subject/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX schema: <http://schema.org/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX school: <http://edu.ontotext.com/resource/school/>
+PREFIX school: <https://schools.ontotext.com/resource/school/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 select ?oblLabel ?munLabel ?placeLabel ?school_id ?school_wd ?school_label ?subject_label ?score_21 ?kids_21
 where {

--- a/data/core/geography/queries/geosparql-enable.ru
+++ b/data/core/geography/queries/geosparql-enable.ru
@@ -4,9 +4,9 @@ PREFIX sf: <http://www.opengis.net/ont/sf#>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX geo-pos: <http://www.w3.org/2003/01/geo/wgs84_pos#>
-clear silent graph <https://schools.ontotext.com/resource/graph/geo-coord-pairs> ;
+clear silent graph <https://schools.ontotext.com/data/resource/graph/geo-coord-pairs> ;
 insert {
-    graph <https://schools.ontotext.com/resource/graph/geo-coord-pairs> {
+    graph <https://schools.ontotext.com/data/resource/graph/geo-coord-pairs> {
     ?point geo-pos:lat ?lat ;
            geo-pos:long ?lon .
 	}

--- a/data/core/geography/queries/geosparql-enable.ru
+++ b/data/core/geography/queries/geosparql-enable.ru
@@ -4,9 +4,9 @@ PREFIX sf: <http://www.opengis.net/ont/sf#>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX geo-pos: <http://www.w3.org/2003/01/geo/wgs84_pos#>
-clear silent graph <http://edu.ontotext.com/resource/graph/geo-coord-pairs> ;
+clear silent graph <https://schools.ontotext.com/resource/graph/geo-coord-pairs> ;
 insert {
-    graph <http://edu.ontotext.com/resource/graph/geo-coord-pairs> {
+    graph <https://schools.ontotext.com/resource/graph/geo-coord-pairs> {
     ?point geo-pos:lat ?lat ;
            geo-pos:long ?lon .
 	}

--- a/data/core/geography/queries/jurisdictions.ru
+++ b/data/core/geography/queries/jurisdictions.ru
@@ -3,10 +3,10 @@ PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wd: <http://www.wikidata.org/entity/>
-PREFIX place: <http://edu.ontotext.com/resource/place/>
+PREFIX place: <https://schools.ontotext.com/resource/place/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX schema: <http://schema.org/>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 PREFIX sf: <http://www.opengis.net/ont/sf#>
 INSERT {
     GRAPH place: {

--- a/data/core/geography/queries/jurisdictions.ru
+++ b/data/core/geography/queries/jurisdictions.ru
@@ -3,10 +3,10 @@ PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wd: <http://www.wikidata.org/entity/>
-PREFIX place: <https://schools.ontotext.com/resource/place/>
+PREFIX place: <https://schools.ontotext.com/data/resource/place/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX schema: <http://schema.org/>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 PREFIX sf: <http://www.opengis.net/ont/sf#>
 INSERT {
     GRAPH place: {

--- a/data/core/geography/queries/osm-ids.rq
+++ b/data/core/geography/queries/osm-ids.rq
@@ -1,4 +1,4 @@
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 select * where {
 	?s :osmID ?osm .
 }

--- a/data/core/geography/queries/osm-ids.rq
+++ b/data/core/geography/queries/osm-ids.rq
@@ -1,4 +1,4 @@
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 select * where {
 	?s :osmID ?osm .
 }

--- a/data/core/geography/queries/places.ru
+++ b/data/core/geography/queries/places.ru
@@ -3,10 +3,10 @@ PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wd: <http://www.wikidata.org/entity/>
-PREFIX place: <http://edu.ontotext.com/resource/place/>
+PREFIX place: <https://schools.ontotext.com/resource/place/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX schema: <http://schema.org/>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 PREFIX sf: <http://www.opengis.net/ont/sf#>
 INSERT {
     GRAPH place: {

--- a/data/core/geography/queries/places.ru
+++ b/data/core/geography/queries/places.ru
@@ -3,10 +3,10 @@ PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wd: <http://www.wikidata.org/entity/>
-PREFIX place: <https://schools.ontotext.com/resource/place/>
+PREFIX place: <https://schools.ontotext.com/data/resource/place/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX schema: <http://schema.org/>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 PREFIX sf: <http://www.opengis.net/ont/sf#>
 INSERT {
     GRAPH place: {

--- a/data/core/geography/queries/polygons_construct.ru
+++ b/data/core/geography/queries/polygons_construct.ru
@@ -7,8 +7,8 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX sf: <http://www.opengis.net/ont/sf#>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
-PREFIX place: <https://schools.ontotext.com/resource/place/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
+PREFIX place: <https://schools.ontotext.com/data/resource/place/>
 
 INSERT {
     GRAPH place:shapes {

--- a/data/core/geography/queries/polygons_construct.ru
+++ b/data/core/geography/queries/polygons_construct.ru
@@ -7,8 +7,8 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX sf: <http://www.opengis.net/ont/sf#>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
-PREFIX place: <http://edu.ontotext.com/resource/place/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX place: <https://schools.ontotext.com/resource/place/>
 
 INSERT {
     GRAPH place:shapes {

--- a/data/core/schools/from_wikidata.ru
+++ b/data/core/schools/from_wikidata.ru
@@ -1,11 +1,11 @@
-PREFIX school: <http://edu.ontotext.com/resource/school/>
+PREFIX school: <https://schools.ontotext.com/resource/school/>
 PREFIX sf: <http://www.opengis.net/ont/sf#>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX schema: <http://schema.org/>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wd: <http://www.wikidata.org/entity/>
-PREFIX place: <http://edu.ontotext.com/resource/place/>
+PREFIX place: <https://schools.ontotext.com/resource/place/>
 INSERT {
     GRAPH school: {
         ?SCHOOL a :School ;

--- a/data/core/schools/from_wikidata.ru
+++ b/data/core/schools/from_wikidata.ru
@@ -1,11 +1,11 @@
-PREFIX school: <https://schools.ontotext.com/resource/school/>
+PREFIX school: <https://schools.ontotext.com/data/resource/school/>
 PREFIX sf: <http://www.opengis.net/ont/sf#>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX schema: <http://schema.org/>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wd: <http://www.wikidata.org/entity/>
-PREFIX place: <https://schools.ontotext.com/resource/place/>
+PREFIX place: <https://schools.ontotext.com/data/resource/place/>
 INSERT {
     GRAPH school: {
         ?SCHOOL a :School ;

--- a/data/observations/dataset_insert.ru
+++ b/data/observations/dataset_insert.ru
@@ -1,10 +1,10 @@
 ## ugly hack INSERT PATTERN FOR dataset.ttl
 
-BASE <http://edu.ontotext.com/resource/>
+BASE <https://schools.ontotext.com/resource/>
 PREFIX qb: <http://purl.org/linked-data/cube#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 insert data {
     graph <cube/place_summary> {
         <cube/place_summary> a qb:DSD ;

--- a/data/observations/dataset_insert.ru
+++ b/data/observations/dataset_insert.ru
@@ -1,10 +1,10 @@
 ## ugly hack INSERT PATTERN FOR dataset.ttl
 
-BASE <https://schools.ontotext.com/resource/>
+BASE <https://schools.ontotext.com/data/resource/>
 PREFIX qb: <http://purl.org/linked-data/cube#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 insert data {
     graph <cube/place_summary> {
         <cube/place_summary> a qb:DSD ;

--- a/data/observations/dzi/rank_percentiles.ru
+++ b/data/observations/dzi/rank_percentiles.ru
@@ -2,9 +2,9 @@
 ### !!! Assumes qb:Dataset uri is same as dataset context
 ### Finish when gdb 90sec. timeout is removed
 
-PREFIX subject: <https://schools.ontotext.com/resource/subject/>
+PREFIX subject: <https://schools.ontotext.com/data/resource/subject/>
 PREFIX qb: <http://purl.org/linked-data/cube#>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 #INSERT {
 #    GRAPH ?G {

--- a/data/observations/dzi/rank_percentiles.ru
+++ b/data/observations/dzi/rank_percentiles.ru
@@ -2,9 +2,9 @@
 ### !!! Assumes qb:Dataset uri is same as dataset context
 ### Finish when gdb 90sec. timeout is removed
 
-PREFIX subject: <http://edu.ontotext.com/resource/subject/>
+PREFIX subject: <https://schools.ontotext.com/resource/subject/>
 PREFIX qb: <http://purl.org/linked-data/cube#>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 #INSERT {
 #    GRAPH ?G {

--- a/data/observations/nsi_deaths/data/construct.ru
+++ b/data/observations/nsi_deaths/data/construct.ru
@@ -1,6 +1,6 @@
 #http://edu.ontotext.com/orefine/project?project=1762175864737
 
-BASE <http://edu.ontotext.com/resource/>
+BASE <https://schools.ontotext.com/resource/>
 PREFIX mapper: <http://www.ontotext.com/mapper/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -8,11 +8,11 @@ PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX school: <http://edu.ontotext.com/resource/school/>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX school: <https://schools.ontotext.com/resource/school/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 PREFIX qb: <http://purl.org/linked-data/cube#>
-PREFIX place: <http://edu.ontotext.com/resource/place/>
-PREFIX week_number: <http://edu.ontotext.com/resource/week_number/>
+PREFIX place: <https://schools.ontotext.com/resource/place/>
+PREFIX week_number: <https://schools.ontotext.com/resource/week_number/>
 #http://edu.ontotext.com/orefine/project?project=1655428113622
 INSERT {
     GRAPH ?DataSet {

--- a/data/observations/nsi_deaths/data/construct.ru
+++ b/data/observations/nsi_deaths/data/construct.ru
@@ -1,6 +1,6 @@
 #http://edu.ontotext.com/orefine/project?project=1762175864737
 
-BASE <https://schools.ontotext.com/resource/>
+BASE <https://schools.ontotext.com/data/resource/>
 PREFIX mapper: <http://www.ontotext.com/mapper/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -8,11 +8,11 @@ PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX school: <https://schools.ontotext.com/resource/school/>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX school: <https://schools.ontotext.com/data/resource/school/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 PREFIX qb: <http://purl.org/linked-data/cube#>
-PREFIX place: <https://schools.ontotext.com/resource/place/>
-PREFIX week_number: <https://schools.ontotext.com/resource/week_number/>
+PREFIX place: <https://schools.ontotext.com/data/resource/place/>
+PREFIX week_number: <https://schools.ontotext.com/data/resource/week_number/>
 #http://edu.ontotext.com/orefine/project?project=1655428113622
 INSERT {
     GRAPH ?DataSet {

--- a/data/observations/nsi_ethnicity/data/construct.ru
+++ b/data/observations/nsi_ethnicity/data/construct.ru
@@ -1,10 +1,10 @@
 PREFIX qb: <http://purl.org/linked-data/cube#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX ethnic_group: <https://schools.ontotext.com/resource/ethnic_group/>
+PREFIX ethnic_group: <https://schools.ontotext.com/data/resource/ethnic_group/>
 PREFIX mapper: <http://www.ontotext.com/mapper/>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
-PREFIX place: <https://schools.ontotext.com/resource/place/>
-BASE <https://schools.ontotext.com/resource/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
+PREFIX place: <https://schools.ontotext.com/data/resource/place/>
+BASE <https://schools.ontotext.com/data/resource/>
 INSERT {
     GRAPH ?DataSet {
     ?URI_BG_OK a qb:Observation ;

--- a/data/observations/nsi_ethnicity/data/construct.ru
+++ b/data/observations/nsi_ethnicity/data/construct.ru
@@ -1,10 +1,10 @@
 PREFIX qb: <http://purl.org/linked-data/cube#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX ethnic_group: <http://edu.ontotext.com/resource/ethnic_group/>
+PREFIX ethnic_group: <https://schools.ontotext.com/resource/ethnic_group/>
 PREFIX mapper: <http://www.ontotext.com/mapper/>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
-PREFIX place: <http://edu.ontotext.com/resource/place/>
-BASE <http://edu.ontotext.com/resource/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX place: <https://schools.ontotext.com/resource/place/>
+BASE <https://schools.ontotext.com/resource/>
 INSERT {
     GRAPH ?DataSet {
     ?URI_BG_OK a qb:Observation ;

--- a/data/observations/place_summary/construct.ru
+++ b/data/observations/place_summary/construct.ru
@@ -1,6 +1,6 @@
 BASE <https://schools.ontotext.com/data/resource/>
 PREFIX qb: <http://purl.org/linked-data/cube#>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

--- a/data/observations/place_summary/construct.ru
+++ b/data/observations/place_summary/construct.ru
@@ -1,6 +1,6 @@
 BASE <https://schools.ontotext.com/data/resource/>
 PREFIX qb: <http://purl.org/linked-data/cube#>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>

--- a/data/observations/teachers_by_age_region/2020-09-15_M/construct.ru
+++ b/data/observations/teachers_by_age_region/2020-09-15_M/construct.ru
@@ -1,9 +1,9 @@
 PREFIX qb: <http://purl.org/linked-data/cube#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX subject: <http://edu.ontotext.com/resource/subject/>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX subject: <https://schools.ontotext.com/resource/subject/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 PREFIX mapper: <http://www.ontotext.com/mapper/>
-BASE <http://edu.ontotext.com/resource/>
+BASE <https://schools.ontotext.com/resource/>
 INSERT {
     GRAPH ?DataSet {
     ?URI_OK a qb:Observation ;

--- a/data/observations/teachers_by_age_region/2020-09-15_M/construct.ru
+++ b/data/observations/teachers_by_age_region/2020-09-15_M/construct.ru
@@ -1,9 +1,9 @@
 PREFIX qb: <http://purl.org/linked-data/cube#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX subject: <https://schools.ontotext.com/resource/subject/>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX subject: <https://schools.ontotext.com/data/resource/subject/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 PREFIX mapper: <http://www.ontotext.com/mapper/>
-BASE <https://schools.ontotext.com/resource/>
+BASE <https://schools.ontotext.com/data/resource/>
 INSERT {
     GRAPH ?DataSet {
     ?URI_OK a qb:Observation ;

--- a/data/observations/teachers_school_subject/2020-15-09/construct.ru
+++ b/data/observations/teachers_school_subject/2020-15-09/construct.ru
@@ -1,10 +1,10 @@
-BASE <http://edu.ontotext.com/resource/>
+BASE <https://schools.ontotext.com/resource/>
 PREFIX qb: <http://purl.org/linked-data/cube#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX subject: <http://edu.ontotext.com/resource/subject/>
-PREFIX : <http://edu.ontotext.com/resource/ontology/>
+PREFIX subject: <https://schools.ontotext.com/resource/subject/>
+PREFIX : <https://schools.ontotext.com/resource/ontology/>
 PREFIX mapper: <http://www.ontotext.com/mapper/>
-PREFIX school: <http://edu.ontotext.com/resource/school/>
+PREFIX school: <https://schools.ontotext.com/resource/school/>
 
 #Project http://edu.ontotext.com/orefine/project?project=2230913364235
 

--- a/data/observations/teachers_school_subject/2020-15-09/construct.ru
+++ b/data/observations/teachers_school_subject/2020-15-09/construct.ru
@@ -1,10 +1,10 @@
-BASE <https://schools.ontotext.com/resource/>
+BASE <https://schools.ontotext.com/data/resource/>
 PREFIX qb: <http://purl.org/linked-data/cube#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX subject: <https://schools.ontotext.com/resource/subject/>
-PREFIX : <https://schools.ontotext.com/resource/ontology/>
+PREFIX subject: <https://schools.ontotext.com/data/resource/subject/>
+PREFIX : <https://schools.ontotext.com/data/resource/ontology/>
 PREFIX mapper: <http://www.ontotext.com/mapper/>
-PREFIX school: <https://schools.ontotext.com/resource/school/>
+PREFIX school: <https://schools.ontotext.com/data/resource/school/>
 
 #Project http://edu.ontotext.com/orefine/project?project=2230913364235
 

--- a/model/nkpd.ttl
+++ b/model/nkpd.ttl
@@ -1,4 +1,4 @@
-@prefix nkpd: <http://edu.ontotext.com/resource/nkpd/> .
+@prefix nkpd: <https://schools.ontotext.com/resource/nkpd/> .
 
 nkpd: a skos:ConceptScheme ;
     skos:prefLabel "Национална класификация на професиите и длъжностите"@bg ;

--- a/model/nkpd.ttl
+++ b/model/nkpd.ttl
@@ -1,4 +1,4 @@
-@prefix nkpd: <https://schools.ontotext.com/resource/nkpd/> .
+@prefix nkpd: <https://schools.ontotext.com/data/resource/nkpd/> .
 
 nkpd: a skos:ConceptScheme ;
     skos:prefLabel "Национална класификация на професиите и длъжностите"@bg ;

--- a/model/observation.ttl
+++ b/model/observation.ttl
@@ -1,23 +1,23 @@
-@prefix :      <https://schools.ontotext.com/resource/ontology/> .
+@prefix :      <https://schools.ontotext.com/data/resource/ontology/> .
 @prefix qb4st: <http://www.w3.org/ns/qb4st/> .
 @prefix qudt:  <http://qudt.org/schema/qudt/> .
 @prefix pq:    <http://www.wikidata.org/prop/qualifier/> .
 @prefix pr:    <http://www.wikidata.org/prop/reference/> .
-@prefix occupation: <https://schools.ontotext.com/resource/occupation/> .
+@prefix occupation: <https://schools.ontotext.com/data/resource/occupation/> .
 @prefix ps:    <http://www.wikidata.org/prop/statement/> .
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
-@prefix subject: <https://schools.ontotext.com/resource/subject/> .
+@prefix subject: <https://schools.ontotext.com/data/resource/subject/> .
 @prefix sdmx:  <http://purl.org/linked-data/sdmx#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix pqn:   <http://www.wikidata.org/prop/qualifier/value-normalized/> .
 @prefix qb:    <http://purl.org/linked-data/cube#> .
 @prefix pqv:   <http://www.wikidata.org/prop/qualifier/value/> .
-@prefix school: <https://schools.ontotext.com/resource/school/> .
+@prefix school: <https://schools.ontotext.com/data/resource/school/> .
 @prefix sdmx-concept: <http://purl.org/linked-data/sdmx/2009/concept#> .
 @prefix wdref: <http://www.wikidata.org/reference/> .
 @prefix wdata: <http://www.wikidata.org/wiki/Special:EntityData/> .
-@prefix cube:  <https://schools.ontotext.com/resource/cube/> .
-@prefix age_bracket: <https://schools.ontotext.com/resource/age_bracket/> .
+@prefix cube:  <https://schools.ontotext.com/data/resource/cube/> .
+@prefix age_bracket: <https://schools.ontotext.com/data/resource/age_bracket/> .
 @prefix sdmx-attribute: <http://purl.org/linked-data/sdmx/2009/attribute#> .
 @prefix vann:  <http://purl.org/vocab/vann/> .
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
@@ -25,7 +25,7 @@
 @prefix wgs:   <http://www.w3.org/2003/01/geo/wgs84_pos#> .
 @prefix wikibase: <http://wikiba.se/ontology#> .
 @prefix prn:   <http://www.wikidata.org/prop/reference/value-normalized/> .
-@prefix graph: <https://schools.ontotext.com/resource/graph/> .
+@prefix graph: <https://schools.ontotext.com/data/resource/graph/> .
 @prefix unit:  <http://qudt.org/vocab/unit/> .
 @prefix oeev:  <http://www.phenome-fppn.fr/vocabulary/2018/oeev#> .
 @prefix prv:   <http://www.wikidata.org/prop/reference/value/> .
@@ -45,10 +45,10 @@
 @prefix sf:    <http://www.opengis.net/ont/sf#> .
 @prefix dct:   <http://purl.org/dc/terms/> .
 @prefix gas:   <http://www.bigdata.com/rdf/gas#> .
-@prefix ethnic_group: <https://schools.ontotext.com/resource/ethnic_group/> .
-@prefix place: <https://schools.ontotext.com/resource/place/> .
+@prefix ethnic_group: <https://schools.ontotext.com/data/resource/ethnic_group/> .
+@prefix place: <https://schools.ontotext.com/data/resource/place/> .
 @prefix prov:  <http://www.w3.org/ns/prov#> .
-@prefix sex:   <https://schools.ontotext.com/resource/sex/> .
+@prefix sex:   <https://schools.ontotext.com/data/resource/sex/> .
 @prefix quantitykind: <http://qudt.org/vocab/quantitykind/> .
 @prefix p:     <http://www.wikidata.org/prop/> .
 @prefix bds:   <http://www.bigdata.com/rdf/search#> .
@@ -57,7 +57,7 @@
 @prefix obo:   <http://purl.obolibrary.org/obo/> .
 @prefix dc:    <http://purl.org/dc/elements/1.1/> .
 
-<https://schools.ontotext.com/resource/cube/dzi/2020>
+<https://schools.ontotext.com/data/resource/cube/dzi/2020>
         rdf:type      qb:DataSet ;
         rdfs:comment  "Резултати от държавен зрелсотен изпит - 2020 "@bg ;
         rdfs:label    "DZI - 2020" ;
@@ -65,7 +65,7 @@
         :grade_level  12 ;
         qb:structure  cube:dzi .
 
-<https://schools.ontotext.com/resource/cube/dzi/2021/10c6935ff73c4985e23cc314a6e9ec87>
+<https://schools.ontotext.com/data/resource/cube/dzi/2021/10c6935ff73c4985e23cc314a6e9ec87>
         rdf:type          qb:Observation ;
         :date             "2021-05-19"^^xsd:date ;
         :eval_score       4.3E0 ;
@@ -75,14 +75,14 @@
         :rank_percentile  54.96 ;
         :school           school:2222009 ;
         :subject          subject:nmb_35 ;
-        qb:dataSet        <https://schools.ontotext.com/resource/cube/dzi/2021> .
+        qb:dataSet        <https://schools.ontotext.com/data/resource/cube/dzi/2021> .
 
 subject:nmb_1  rdf:type   skos:Concept , :Subject ;
         skos:inScheme     subject: ;
         skos:notation     "БЕЛ"@bg ;
         skos:prefLabel    "Български език и литература"@bg .
 
-<https://schools.ontotext.com/resource/cube/dzi/2020/10c6935ff73c4985e23cc314a6e9ec87>
+<https://schools.ontotext.com/data/resource/cube/dzi/2020/10c6935ff73c4985e23cc314a6e9ec87>
         rdf:type          qb:Observation ;
         :date             "2020-06-04"^^xsd:date ;
         :eval_score       4.54E0 ;
@@ -92,14 +92,14 @@ subject:nmb_1  rdf:type   skos:Concept , :Subject ;
         :rank_percentile  57.76 ;
         :school           school:2222009 ;
         :subject          subject:nmb_35 ;
-        qb:dataSet        <https://schools.ontotext.com/resource/cube/dzi/2020> .
+        qb:dataSet        <https://schools.ontotext.com/data/resource/cube/dzi/2020> .
 
 subject:nmb_35  rdf:type  skos:Concept , :Subject ;
         skos:inScheme     subject: ;
         skos:notation     "МАТ"@bg ;
         skos:prefLabel    "Математика"@bg .
 
-<https://schools.ontotext.com/resource/cube/dzi/2021>
+<https://schools.ontotext.com/data/resource/cube/dzi/2021>
         rdf:type      qb:DataSet ;
         rdfs:comment  "Резултати от държавен зрелсотен изпит - 2021 "@bg ;
         rdfs:label    "DZI - 2021" ;
@@ -107,7 +107,7 @@ subject:nmb_35  rdf:type  skos:Concept , :Subject ;
         :grade_level  12 ;
         qb:structure  cube:dzi .
 
-<https://schools.ontotext.com/resource/cube/dzi/2020/53bf3915670608ee06714f9ac828c8a2>
+<https://schools.ontotext.com/data/resource/cube/dzi/2020/53bf3915670608ee06714f9ac828c8a2>
         rdf:type          qb:Observation ;
         :date             "2020-06-04"^^xsd:date ;
         :eval_score       5.45E0 ;
@@ -117,9 +117,9 @@ subject:nmb_35  rdf:type  skos:Concept , :Subject ;
         :rank_percentile  99.16;
         :school           school:2222009 ;
         :subject          subject:nmb_1 ;
-        qb:dataSet        <https://schools.ontotext.com/resource/cube/dzi/2020> .
+        qb:dataSet        <https://schools.ontotext.com/data/resource/cube/dzi/2020> .
 
-<https://schools.ontotext.com/resource/cube/dzi/2021/53bf3915670608ee06714f9ac828c8a2>
+<https://schools.ontotext.com/data/resource/cube/dzi/2021/53bf3915670608ee06714f9ac828c8a2>
         rdf:type          qb:Observation ;
         :date             "2021-05-19"^^xsd:date ;
         :eval_score       5.26E0 ;
@@ -129,7 +129,7 @@ subject:nmb_35  rdf:type  skos:Concept , :Subject ;
         :rank_percentile  97.8947368421052631578947 ;
         :school           school:2222009 ;
         :subject          subject:nmb_1 ;
-        qb:dataSet        <https://schools.ontotext.com/resource/cube/dzi/2021> .
+        qb:dataSet        <https://schools.ontotext.com/data/resource/cube/dzi/2021> .
 
 <school/2222009> a schema:School ;
     schema:name "9 Френска езикова гимназия Алфонс дьо Ламартин"@bg ;
@@ -137,10 +137,10 @@ subject:nmb_35  rdf:type  skos:Concept , :Subject ;
 
 #PUML
 
-<https://schools.ontotext.com/resource/cube/dzi/2021/53bf3915670608ee06714f9ac828c8a2> puml:up <school/2222009> .
-<https://schools.ontotext.com/resource/cube/dzi/2020/53bf3915670608ee06714f9ac828c8a2> puml:up <school/2222009> .
-<https://schools.ontotext.com/resource/cube/dzi/2020/10c6935ff73c4985e23cc314a6e9ec87> puml:up <school/2222009> .
-<https://schools.ontotext.com/resource/cube/dzi/2021/10c6935ff73c4985e23cc314a6e9ec87> puml:up <school/2222009> .
+<https://schools.ontotext.com/data/resource/cube/dzi/2021/53bf3915670608ee06714f9ac828c8a2> puml:up <school/2222009> .
+<https://schools.ontotext.com/data/resource/cube/dzi/2020/53bf3915670608ee06714f9ac828c8a2> puml:up <school/2222009> .
+<https://schools.ontotext.com/data/resource/cube/dzi/2020/10c6935ff73c4985e23cc314a6e9ec87> puml:up <school/2222009> .
+<https://schools.ontotext.com/data/resource/cube/dzi/2021/10c6935ff73c4985e23cc314a6e9ec87> puml:up <school/2222009> .
 
 # PUML
 

--- a/model/observation.ttl
+++ b/model/observation.ttl
@@ -1,23 +1,23 @@
-@prefix :      <http://edu.ontotext.com/resource/ontology/> .
+@prefix :      <https://schools.ontotext.com/resource/ontology/> .
 @prefix qb4st: <http://www.w3.org/ns/qb4st/> .
 @prefix qudt:  <http://qudt.org/schema/qudt/> .
 @prefix pq:    <http://www.wikidata.org/prop/qualifier/> .
 @prefix pr:    <http://www.wikidata.org/prop/reference/> .
-@prefix occupation: <http://edu.ontotext.com/resource/occupation/> .
+@prefix occupation: <https://schools.ontotext.com/resource/occupation/> .
 @prefix ps:    <http://www.wikidata.org/prop/statement/> .
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
-@prefix subject: <http://edu.ontotext.com/resource/subject/> .
+@prefix subject: <https://schools.ontotext.com/resource/subject/> .
 @prefix sdmx:  <http://purl.org/linked-data/sdmx#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix pqn:   <http://www.wikidata.org/prop/qualifier/value-normalized/> .
 @prefix qb:    <http://purl.org/linked-data/cube#> .
 @prefix pqv:   <http://www.wikidata.org/prop/qualifier/value/> .
-@prefix school: <http://edu.ontotext.com/resource/school/> .
+@prefix school: <https://schools.ontotext.com/resource/school/> .
 @prefix sdmx-concept: <http://purl.org/linked-data/sdmx/2009/concept#> .
 @prefix wdref: <http://www.wikidata.org/reference/> .
 @prefix wdata: <http://www.wikidata.org/wiki/Special:EntityData/> .
-@prefix cube:  <http://edu.ontotext.com/resource/cube/> .
-@prefix age_bracket: <http://edu.ontotext.com/resource/age_bracket/> .
+@prefix cube:  <https://schools.ontotext.com/resource/cube/> .
+@prefix age_bracket: <https://schools.ontotext.com/resource/age_bracket/> .
 @prefix sdmx-attribute: <http://purl.org/linked-data/sdmx/2009/attribute#> .
 @prefix vann:  <http://purl.org/vocab/vann/> .
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
@@ -25,7 +25,7 @@
 @prefix wgs:   <http://www.w3.org/2003/01/geo/wgs84_pos#> .
 @prefix wikibase: <http://wikiba.se/ontology#> .
 @prefix prn:   <http://www.wikidata.org/prop/reference/value-normalized/> .
-@prefix graph: <http://edu.ontotext.com/resource/graph/> .
+@prefix graph: <https://schools.ontotext.com/resource/graph/> .
 @prefix unit:  <http://qudt.org/vocab/unit/> .
 @prefix oeev:  <http://www.phenome-fppn.fr/vocabulary/2018/oeev#> .
 @prefix prv:   <http://www.wikidata.org/prop/reference/value/> .
@@ -45,10 +45,10 @@
 @prefix sf:    <http://www.opengis.net/ont/sf#> .
 @prefix dct:   <http://purl.org/dc/terms/> .
 @prefix gas:   <http://www.bigdata.com/rdf/gas#> .
-@prefix ethnic_group: <http://edu.ontotext.com/resource/ethnic_group/> .
-@prefix place: <http://edu.ontotext.com/resource/place/> .
+@prefix ethnic_group: <https://schools.ontotext.com/resource/ethnic_group/> .
+@prefix place: <https://schools.ontotext.com/resource/place/> .
 @prefix prov:  <http://www.w3.org/ns/prov#> .
-@prefix sex:   <http://edu.ontotext.com/resource/sex/> .
+@prefix sex:   <https://schools.ontotext.com/resource/sex/> .
 @prefix quantitykind: <http://qudt.org/vocab/quantitykind/> .
 @prefix p:     <http://www.wikidata.org/prop/> .
 @prefix bds:   <http://www.bigdata.com/rdf/search#> .
@@ -57,7 +57,7 @@
 @prefix obo:   <http://purl.obolibrary.org/obo/> .
 @prefix dc:    <http://purl.org/dc/elements/1.1/> .
 
-<http://edu.ontotext.com/resource/cube/dzi/2020>
+<https://schools.ontotext.com/resource/cube/dzi/2020>
         rdf:type      qb:DataSet ;
         rdfs:comment  "Резултати от държавен зрелсотен изпит - 2020 "@bg ;
         rdfs:label    "DZI - 2020" ;
@@ -65,7 +65,7 @@
         :grade_level  12 ;
         qb:structure  cube:dzi .
 
-<http://edu.ontotext.com/resource/cube/dzi/2021/10c6935ff73c4985e23cc314a6e9ec87>
+<https://schools.ontotext.com/resource/cube/dzi/2021/10c6935ff73c4985e23cc314a6e9ec87>
         rdf:type          qb:Observation ;
         :date             "2021-05-19"^^xsd:date ;
         :eval_score       4.3E0 ;
@@ -75,14 +75,14 @@
         :rank_percentile  54.96 ;
         :school           school:2222009 ;
         :subject          subject:nmb_35 ;
-        qb:dataSet        <http://edu.ontotext.com/resource/cube/dzi/2021> .
+        qb:dataSet        <https://schools.ontotext.com/resource/cube/dzi/2021> .
 
 subject:nmb_1  rdf:type   skos:Concept , :Subject ;
         skos:inScheme     subject: ;
         skos:notation     "БЕЛ"@bg ;
         skos:prefLabel    "Български език и литература"@bg .
 
-<http://edu.ontotext.com/resource/cube/dzi/2020/10c6935ff73c4985e23cc314a6e9ec87>
+<https://schools.ontotext.com/resource/cube/dzi/2020/10c6935ff73c4985e23cc314a6e9ec87>
         rdf:type          qb:Observation ;
         :date             "2020-06-04"^^xsd:date ;
         :eval_score       4.54E0 ;
@@ -92,14 +92,14 @@ subject:nmb_1  rdf:type   skos:Concept , :Subject ;
         :rank_percentile  57.76 ;
         :school           school:2222009 ;
         :subject          subject:nmb_35 ;
-        qb:dataSet        <http://edu.ontotext.com/resource/cube/dzi/2020> .
+        qb:dataSet        <https://schools.ontotext.com/resource/cube/dzi/2020> .
 
 subject:nmb_35  rdf:type  skos:Concept , :Subject ;
         skos:inScheme     subject: ;
         skos:notation     "МАТ"@bg ;
         skos:prefLabel    "Математика"@bg .
 
-<http://edu.ontotext.com/resource/cube/dzi/2021>
+<https://schools.ontotext.com/resource/cube/dzi/2021>
         rdf:type      qb:DataSet ;
         rdfs:comment  "Резултати от държавен зрелсотен изпит - 2021 "@bg ;
         rdfs:label    "DZI - 2021" ;
@@ -107,7 +107,7 @@ subject:nmb_35  rdf:type  skos:Concept , :Subject ;
         :grade_level  12 ;
         qb:structure  cube:dzi .
 
-<http://edu.ontotext.com/resource/cube/dzi/2020/53bf3915670608ee06714f9ac828c8a2>
+<https://schools.ontotext.com/resource/cube/dzi/2020/53bf3915670608ee06714f9ac828c8a2>
         rdf:type          qb:Observation ;
         :date             "2020-06-04"^^xsd:date ;
         :eval_score       5.45E0 ;
@@ -117,9 +117,9 @@ subject:nmb_35  rdf:type  skos:Concept , :Subject ;
         :rank_percentile  99.16;
         :school           school:2222009 ;
         :subject          subject:nmb_1 ;
-        qb:dataSet        <http://edu.ontotext.com/resource/cube/dzi/2020> .
+        qb:dataSet        <https://schools.ontotext.com/resource/cube/dzi/2020> .
 
-<http://edu.ontotext.com/resource/cube/dzi/2021/53bf3915670608ee06714f9ac828c8a2>
+<https://schools.ontotext.com/resource/cube/dzi/2021/53bf3915670608ee06714f9ac828c8a2>
         rdf:type          qb:Observation ;
         :date             "2021-05-19"^^xsd:date ;
         :eval_score       5.26E0 ;
@@ -129,7 +129,7 @@ subject:nmb_35  rdf:type  skos:Concept , :Subject ;
         :rank_percentile  97.8947368421052631578947 ;
         :school           school:2222009 ;
         :subject          subject:nmb_1 ;
-        qb:dataSet        <http://edu.ontotext.com/resource/cube/dzi/2021> .
+        qb:dataSet        <https://schools.ontotext.com/resource/cube/dzi/2021> .
 
 <school/2222009> a schema:School ;
     schema:name "9 Френска езикова гимназия Алфонс дьо Ламартин"@bg ;
@@ -137,10 +137,10 @@ subject:nmb_35  rdf:type  skos:Concept , :Subject ;
 
 #PUML
 
-<http://edu.ontotext.com/resource/cube/dzi/2021/53bf3915670608ee06714f9ac828c8a2> puml:up <school/2222009> .
-<http://edu.ontotext.com/resource/cube/dzi/2020/53bf3915670608ee06714f9ac828c8a2> puml:up <school/2222009> .
-<http://edu.ontotext.com/resource/cube/dzi/2020/10c6935ff73c4985e23cc314a6e9ec87> puml:up <school/2222009> .
-<http://edu.ontotext.com/resource/cube/dzi/2021/10c6935ff73c4985e23cc314a6e9ec87> puml:up <school/2222009> .
+<https://schools.ontotext.com/resource/cube/dzi/2021/53bf3915670608ee06714f9ac828c8a2> puml:up <school/2222009> .
+<https://schools.ontotext.com/resource/cube/dzi/2020/53bf3915670608ee06714f9ac828c8a2> puml:up <school/2222009> .
+<https://schools.ontotext.com/resource/cube/dzi/2020/10c6935ff73c4985e23cc314a6e9ec87> puml:up <school/2222009> .
+<https://schools.ontotext.com/resource/cube/dzi/2021/10c6935ff73c4985e23cc314a6e9ec87> puml:up <school/2222009> .
 
 # PUML
 


### PR DESCRIPTION
Replace edu.ontotext.com with schools.ontotext.com

I guess such change happened in the past, because the models/prefixes.ttl
uses schools.ontotext.com, but the files under data/ analysis/ were using
edu.ontotext.com.

The actual replacement I did is:
`<http://edu.ontotext.com/` -> `<https://schools.ontotext.com/`

After some testing I made another replace:
`<https://schools.ontotext.com/resource/` -> `<https://schools.ontotext.com/data/resource/`
(the second replace made deleted some trailing whitespaces, so the diff is quite colorful ...) 