### PR TITLE
Re-working streamlit dashboard deployment logic

### DIFF
--- a/dashboards/dzi-streamlit/Makefile
+++ b/dashboards/dzi-streamlit/Makefile
@@ -1,0 +1,29 @@
+# Define the image name
+IMAGE_NAME=data-for-good-bg/eddata
+
+# Define the Dockerfile and build context
+DOCKERFILE=Dockerfile
+BUILD_CONTEXT=.
+
+
+.PHONY: help build-prod build-staging
+
+# https://stackoverflow.com/a/35730928
+
+# Show this help.
+help:
+	@awk '/^#/{c=substr($$0,3);next}c&&/^[[:alpha:]][[:alnum:]_-]+:/{print substr($$1,1,index($$1,":")),c}1{c=0}' $(MAKEFILE_LIST) | column -s: -t
+
+
+# Builds production docker image with production tag
+build-prod:
+	@if [ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then \
+		echo "Error: You must be on the 'main' branch to build the production image."; \
+		exit 1; \
+	fi
+	docker build -t $(IMAGE_NAME):production -f $(DOCKERFILE) $(BUILD_CONTEXT)
+
+
+# Builds production docker image with staging tag
+build-staging:
+	docker build -t $(IMAGE_NAME):staging -f $(DOCKERFILE) $(BUILD_CONTEXT)

--- a/dashboards/dzi-streamlit/README.md
+++ b/dashboards/dzi-streamlit/README.md
@@ -1,0 +1,93 @@
+This directory contains a Streamlit application for presenting
+the educational data.
+
+Initially it was started as dashboard for DZI data, but later we
+decided that this app will present the NVO data as well.
+
+
+# Directory organization
+
+* `dashboard` directory contains the streamlit application code
+* `docker-compose` directory contains docker-compose project file and
+  also required configuration files
+* In this directory there's also a Dockerfile and Makefile which facilitate
+  building the docker image
+
+* `db-exporter` directory contains outdated helper scripts for extracting
+  csv file from postgres database
+
+
+# Building the docker image
+
+The docker image of the educational dashboard is named `data-for-good-bg/eddata`.
+
+This can happen with the provided Makefile.
+
+It supports building `production` and `staging` images.
+
+At the moment of writing this document the difference between the
+two images is the tag.
+Also when building the production docker image the Makefile will
+validate that the current branch is `main`.
+
+Running the command below will produce the production image:
+```bash
+make build-prod
+```
+
+To build the staging image use:
+```bash
+make build-staging
+```
+
+# Deployment
+
+For deploying the dashboard we use docker compose.
+
+The `./docker-compose` directory contains almost everything
+needed to deploy and run dashboard app.
+
+Currently there's no automated way to deploy the app,
+it is done manually by cloning the repo.
+
+The steps roughly are:
+
+```bash
+
+cd /opt
+
+# 1. clone the repo under the desired name, let say `production-eddata-dashboard`
+git clone https://github.com/data-for-good-bg/semantic-schools.git production-eddata-dashboard
+
+# 2. go to the docker-compose directory
+cd production-eddata-dashboard/dashboards/dzi-streamlit/docker-compose
+
+# 3. Create config/secrets.toml file, see below
+
+# 4. Start the application
+make up-production
+
+# 5. Stopping the application is done similarly
+make down-production
+```
+
+The `config/secrets.tom` file contains information for the
+database connection. It should look like this:
+
+```ini
+[connections.eddata]
+dialect = "postgresql"
+host = "localhost"
+port = "5432"
+database = "<db-name>"
+username = "<username>
+password = "<password>"
+```
+
+The `./docker-compose/prod.env` and `./docker-compose/staging.env`
+contain a list of environment variables which are used in the
+docker-compose.yaml and allow changing the listening port,
+the http path on which the streamlit app is running, etc.
+
+The Makefile provides commands for starting and stopping
+both production and staging instances of the application.

--- a/dashboards/dzi-streamlit/docker-build.sh
+++ b/dashboards/dzi-streamlit/docker-build.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker build -t dzi-streamlit .

--- a/dashboards/dzi-streamlit/docker-compose/Makefile
+++ b/dashboards/dzi-streamlit/docker-compose/Makefile
@@ -1,0 +1,32 @@
+PROD_PROJECT=eddata-prod
+PROD_ENV=./prod.env
+STAGING_PROJECT=eddata-staging
+STAGING_ENV=./staging.env
+
+
+.PHONY: help up-prod down-prod up-staging down-staging
+
+
+# Show this help (https://stackoverflow.com/a/35730928)
+help:
+	@awk '/^#/{c=substr($$0,3);next}c&&/^[[:alpha:]][[:alnum:]_-]+:/{print substr($$1,1,index($$1,":")),c}1{c=0}' $(MAKEFILE_LIST) | column -s: -t
+
+
+# starts production docker-compose service
+up-prod:
+	docker compose --env-file $(PROD_ENV) -p $(PROD_PROJECT) up -d
+
+
+# stops production docker-compose service
+down-prod:
+	docker compose --env-file $(PROD_ENV) -p $(PROD_PROJECT) down
+
+
+# Starts staging docker-compose service
+up-staging:
+	docker compose --env-file $(STAGING_ENV) -p $(STAGING_PROJECT) up -d
+
+
+# Stops staging docker-compose service
+down-staging:
+	docker compose --env-file $(STAGING_ENV) -p $(STAGING_PROJECT) down

--- a/dashboards/dzi-streamlit/docker-compose/README.md
+++ b/dashboards/dzi-streamlit/docker-compose/README.md
@@ -1,0 +1,1 @@
+For details about deployment check the README.md in the parent dir.

--- a/dashboards/dzi-streamlit/docker-compose/config/config.toml
+++ b/dashboards/dzi-streamlit/docker-compose/config/config.toml
@@ -29,9 +29,10 @@ runOnSave = false
 
 address = "127.0.0.1"
 
-port = 8502
-
-baseUrlPath = "/dashboards/dzi"
+# NB: These are now configured via env vars from the docker-compose file
+#
+# port = 8502
+# baseUrlPath = "/dashboards/dzi"
 
 [browser]
 

--- a/dashboards/dzi-streamlit/docker-compose/docker-compose.yaml
+++ b/dashboards/dzi-streamlit/docker-compose/docker-compose.yaml
@@ -1,8 +1,11 @@
 services:
   dashboard:
-    image: "dzi-streamlit"
+    image: "data-for-good-bg/eddata:${IMAGE_TAG}"
+    environment:
+      - STREAMLIT_SERVER_PORT=${SERVER_PORT}
+      - STREAMLIT_SERVER_BASE_URL_PATH=${BASE_URL_PATH}
     ports:
-      - "127.0.0.1:8502:8502"
+      - 127.0.0.1:${SERVER_PORT}:${SERVER_PORT}
     volumes:
       - ./config:/dashboard/.streamlit/
     network_mode: host

--- a/dashboards/dzi-streamlit/docker-compose/prod.env
+++ b/dashboards/dzi-streamlit/docker-compose/prod.env
@@ -1,0 +1,4 @@
+IMAGE_TAG=production
+SERVER_PORT=8503
+
+BASE_URL_PATH=/eddata

--- a/dashboards/dzi-streamlit/docker-compose/staging.env
+++ b/dashboards/dzi-streamlit/docker-compose/staging.env
@@ -1,0 +1,4 @@
+IMAGE_TAG=staging
+SERVER_PORT=8504
+
+BASE_URL_PATH=/dashboards/eddata


### PR DESCRIPTION
Now the build and deployment logic is done in way which allows
running two instances (staging and production) on the same machine.

Check the README file for details.